### PR TITLE
Fix: Adjust GitHub Actions trigger and address Snyk vulnerability (#380)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,9 +10,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "main","developer" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 jobs:
   build:

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -44,5 +44,8 @@
     "jest-environment-jsdom": "^30.0.2",
     "style-loader": "^4.0.0",
     "ts-jest": "^29.4.0"
+  },
+  "overrides": {
+    "brace-expansion": "1.1.12"
   }
 }


### PR DESCRIPTION
- Modifies .github/workflows/maven.yml to trigger on pull requests to the 'develop' branch in addition to 'main'. Also corrects 'developer' to 'develop' in the push trigger.
- Adds an 'overrides' section to frontend-react/package.json to force the version of 'brace-expansion' to 1.1.12, addressing a Snyk-reported ReDoS vulnerability.