### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/isidromerayo/TFG_UNIR/security/code-scanning/16](https://github.com/isidromerayo/TFG_UNIR/security/code-scanning/16)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any write operations on the repository, the permissions can be limited to `contents: read`. This ensures that the workflow has only the minimum access required to execute its tasks.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. This change does not affect the functionality of the workflow but improves its security posture.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
