### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "develop" ]


### PR DESCRIPTION
Potential fix for [https://github.com/isidromerayo/TFG_UNIR/security/code-scanning/15](https://github.com/isidromerayo/TFG_UNIR/security/code-scanning/15)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves checking out code and building it with Maven, it only requires `contents: read` permissions. This ensures that the `GITHUB_TOKEN` is limited to read-only access to the repository contents, mitigating potential security risks.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit permissions specifically for that job. In this case, adding it at the root level is sufficient and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
